### PR TITLE
export PaddleSecrets

### DIFF
--- a/src/Web/Paddle.hs
+++ b/src/Web/Paddle.hs
@@ -19,6 +19,7 @@ module Web.Paddle
   , Web.Paddle.init
   , PaddleProductId(..)
   , PaddleCheckoutId(..)
+  , PaddleSecrets(..)
   , FulfillmentWebhookRequest(..)
   , parseFulfillmentWebhookRequest
   , AlertWebhookRequest(..)


### PR DESCRIPTION
It's required by `init`

cc @nh2 